### PR TITLE
Handle exceptions arising from invalid options

### DIFF
--- a/apps/m17-demod.cpp
+++ b/apps/m17-demod.cpp
@@ -490,7 +490,14 @@ struct Config
             ;
 
         po::variables_map vm;
-        po::store(po::parse_command_line(argc, argv, desc), vm);
+        try {
+            po::store(po::parse_command_line(argc, argv, desc), vm);
+        } catch (po::error& ex)
+        {
+            std::cerr << ex.what() << std::endl;
+            std::cout << desc << std::endl;
+            return std::nullopt;
+        }
 
         if (vm.count("help"))
         {

--- a/apps/m17-gateway-link_demod.cpp
+++ b/apps/m17-gateway-link_demod.cpp
@@ -496,7 +496,14 @@ struct Config
             ;
 
         po::variables_map vm;
-        po::store(po::parse_command_line(argc, argv, desc), vm);
+        try {
+            po::store(po::parse_command_line(argc, argv, desc), vm);
+        } catch (po::error& ex)
+        {
+            std::cerr << ex.what() << std::endl;
+            std::cout << desc << std::endl;
+            return std::nullopt;
+        }
 
         if (vm.count("help"))
         {

--- a/apps/m17-gateway-link_mod.cpp
+++ b/apps/m17-gateway-link_mod.cpp
@@ -116,7 +116,14 @@ struct Config
             ;
 
         po::variables_map vm;
-        po::store(po::parse_command_line(argc, argv, desc), vm);
+        try {
+            po::store(po::parse_command_line(argc, argv, desc), vm);
+        } catch (po::error& ex)
+        {
+            std::cerr << ex.what() << std::endl;
+            std::cout << desc << std::endl;
+            return std::nullopt;
+        }
 
         if (vm.count("help"))
         {

--- a/apps/m17-mod.cpp
+++ b/apps/m17-mod.cpp
@@ -129,7 +129,14 @@ struct Config
             ;
 
         po::variables_map vm;
-        po::store(po::parse_command_line(argc, argv, desc), vm);
+        try {
+            po::store(po::parse_command_line(argc, argv, desc), vm);
+        } catch (po::error& ex)
+        {
+            std::cerr << ex.what() << std::endl;
+            std::cout << desc << std::endl;
+            return std::nullopt;
+        }
 
         if (vm.count("help"))
         {

--- a/apps/m17-rtx-gui.cpp
+++ b/apps/m17-rtx-gui.cpp
@@ -740,7 +740,14 @@ struct Config
             ;
 
         po::variables_map vm;
-        po::store(po::parse_command_line(argc, argv, desc), vm);
+        try {
+            po::store(po::parse_command_line(argc, argv, desc), vm);
+        } catch (po::error& ex)
+        {
+            std::cerr << ex.what() << std::endl;
+            std::cout << desc << std::endl;
+            return std::nullopt;
+        }
 
         if (vm.count("help"))
         {


### PR DESCRIPTION
The tools crash if an invalid option is specified. For example:

```
$ m17-mod --foo
terminate called after throwing an instance of 'boost::wrapexcept<boost::program_options::unknown_option>'
  what():  unrecognised option '--foo'
Aborted (core dumped)
```

With exception handling, the tools terminate cleanly:

```
$ m17-demod --foo
unrecognised option '--foo'
Program options:
  -h [ --help ]           Print this help message and exit.
  -V [ --version ]        Print the application verion and exit.
  -i [ --invert ]         invert the received baseband
  -b [ --noise-blanker ]  noise blanker -- silence likely corrupt audio
  -l [ --lsf ]            display the decoded LSF
  -x [ --bin ]            input packed dibits (default is rrc).
  -r [ --rrc ]            input rrc filtered and scaled symbols (default).
  -s [ --sym ]            input symbols (default is rrc).
  -K [ --encrypt ] arg    hexadecimal string for AES 128, 192 or 256 Key 
                          (default is no encryption).
  -v [ --verbose ]        verbose output
  -d [ --debug ]          debug-level output
  -q [ --quiet ]          silence all output -- no BERT output
```