### PR TITLE
Fix Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
           xcopy Library\bin\api-ms-win-crt-stdio-l1-1-0.dll D:\bin\
           xcopy Library\bin\api-ms-win-crt-locale-l1-1-0.dll D:\bin\
           xcopy Library\bin\api-ms-win-crt-math-l1-1-0.dll D:\bin\
-          xcopy Library\mingw-w64\bin\libwinpthread-1.dll D:\bin\
-          xcopy Library\mingw-w64\bin\libgcc_s_seh-1.dll D:\bin\
+          xcopy Library\bin\libwinpthread-1.dll D:\bin\
+          xcopy Library\bin\libgcc_s_seh-1.dll D:\bin\
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
CI currently fails on Windows. Here's an example of a failed build:

https://github.com/M17-Project/m17-tools/actions/runs/11331352352/job/31511179727

It appears that something in conda has changed, and `libwinpthread-1.dll` and `libgcc_s_seh-1.dll` are installed to a different place.